### PR TITLE
Add message timestamp tracking and age calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A decentralized time capsule system that allows users to store messages that can
 - STX reward system to incentivize recipients
 - Immutable record of message history
 - Transparent and verifiable delivery system
+- Message age tracking and timestamp information
 
 ## Use Cases
 
@@ -20,6 +21,7 @@ A decentralized time capsule system that allows users to store messages that can
 - Future-dated communications
 - Incentivized information delivery
 - Secure time-delayed communications
+- Message authenticity verification through timestamps
 
 ## New Features
 
@@ -28,3 +30,6 @@ Messages can now be marked as encrypted, allowing for end-to-end encryption impl
 
 ### STX Rewards
 Senders can now attach STX tokens as rewards for recipients. The rewards are held in escrow by the contract and automatically transferred to recipients upon message revelation. This creates an incentive mechanism for time-sensitive information delivery.
+
+### Message Timestamps
+Each message now includes a creation timestamp (block height) and supports age tracking functionality. This enables verification of message authenticity and helps track the chronological order of messages.

--- a/contracts/message-capsule.clar
+++ b/contracts/message-capsule.clar
@@ -8,7 +8,8 @@
         unlock-height: uint,
         is-revealed: bool,
         is-encrypted: bool,
-        reward: uint
+        reward: uint,
+        created-at: uint
     }
 )
 
@@ -39,7 +40,8 @@
                 unlock-height: unlock-height,
                 is-revealed: false,
                 is-encrypted: is-encrypted,
-                reward: reward
+                reward: reward,
+                created-at: block-height
             }
         )
         (var-set message-counter (+ message-id u1))
@@ -85,5 +87,13 @@
         (message (unwrap! (map-get? messages { message-id: message-id }) err-message-not-found))
     )
         (>= block-height (get unlock-height message))
+    )
+)
+
+(define-read-only (get-message-age (message-id uint))
+    (let (
+        (message (unwrap! (map-get? messages { message-id: message-id }) err-message-not-found))
+    )
+        (- block-height (get created-at message))
     )
 )

--- a/tests/message-capsule_test.ts
+++ b/tests/message-capsule_test.ts
@@ -74,3 +74,31 @@ Clarinet.test({
         block2.receipts[0].result.expectOk().expectAscii("Hello from the past!");
     },
 });
+
+Clarinet.test({
+    name: "Can get message age",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const wallet1 = accounts.get('wallet_1')!;
+        const wallet2 = accounts.get('wallet_2')!;
+        
+        let block1 = chain.mineBlock([
+            Tx.contractCall('message-capsule', 'store-message', [
+                types.principal(wallet2.address),
+                types.utf8("Hello from the past!"),
+                types.uint(10),
+                types.bool(true),
+                types.uint(1000)
+            ], wallet1.address)
+        ]);
+
+        chain.mineEmptyBlock(5);
+        
+        let block2 = chain.mineBlock([
+            Tx.contractCall('message-capsule', 'get-message-age', [
+                types.uint(0)
+            ], wallet1.address)
+        ]);
+        
+        block2.receipts[0].result.expectOk().expectUint(6);
+    },
+});


### PR DESCRIPTION
This PR enhances the time capsule contract by adding message creation timestamps and age tracking functionality. These additions improve message authenticity verification and provide better historical context for stored messages.

Changes made:
- Added `created-at` field to message storage that records block height at creation time
- Implemented new `get-message-age` read-only function to calculate message age in blocks
- Added corresponding test case for message age functionality
- Updated README to document new timestamp features

Benefits:
- Improved message authenticity verification
- Better tracking of message chronology
- Enhanced historical context for stored messages
- Additional data point for frontend applications

No breaking changes were introduced. All existing functionality remains unchanged.